### PR TITLE
WINPR Void Fix

### DIFF
--- a/winpr/include/winpr/wtypes.h
+++ b/winpr/include/winpr/wtypes.h
@@ -132,7 +132,8 @@ typedef unsigned int ULONG32;
 typedef unsigned __int64 ULONG64;
 typedef wchar_t UNICODE;
 typedef unsigned short USHORT;
-typedef void VOID, *PVOID, *LPVOID;
+#define VOID void
+typedef void *PVOID, *LPVOID;
 typedef void *PVOID64, *LPVOID64;
 typedef const void *LPCVOID;
 typedef unsigned short WORD, *PWORD, *LPWORD;


### PR DESCRIPTION
c++ only allows only void to define empty parameter list
typedef defines a new type therfore its not valid in c++
