### PR TITLE
Parse the Surface frame marker flag

### DIFF
--- a/libfreerdp/core/capabilities.c
+++ b/libfreerdp/core/capabilities.c
@@ -2387,13 +2387,15 @@ BOOL rdp_print_large_pointer_capability_set(wStream* s, UINT16 length)
 
 BOOL rdp_read_surface_commands_capability_set(wStream* s, UINT16 length, rdpSettings* settings)
 {
+	UINT32 cmdFlags;
 	if (length < 12)
 		return FALSE;
 
-	Stream_Seek_UINT32(s); /* cmdFlags (4 bytes) */
+	Stream_Read_UINT32(s, cmdFlags); /* cmdFlags (4 bytes) */
 	Stream_Seek_UINT32(s); /* reserved (4 bytes) */
 
 	settings->SurfaceCommandsEnabled = TRUE;
+	settings->SurfaceFrameMarkerEnabled = (cmdFlags & SURFCMDS_FRAME_MARKER);
 
 	return TRUE;
 }
@@ -2414,9 +2416,10 @@ void rdp_write_surface_commands_capability_set(wStream* s, rdpSettings* settings
 
 	header = rdp_capability_set_start(s);
 
-	cmdFlags = SURFCMDS_FRAME_MARKER |
-			SURFCMDS_SET_SURFACE_BITS |
+	cmdFlags = SURFCMDS_SET_SURFACE_BITS |
 			SURFCMDS_STREAM_SURFACE_BITS;
+	if (settings->SurfaceFrameMarkerEnabled)
+		cmdFlags |= SURFCMDS_FRAME_MARKER;
 
 	Stream_Write_UINT32(s, cmdFlags); /* cmdFlags (4 bytes) */
 	Stream_Write_UINT32(s, 0); /* reserved (4 bytes) */

--- a/libfreerdp/core/settings.c
+++ b/libfreerdp/core/settings.c
@@ -313,6 +313,7 @@ rdpSettings* freerdp_settings_new(DWORD flags)
 		settings->DrawGdiPlusEnabled = FALSE;
 
 		settings->FrameMarkerCommandEnabled = FALSE;
+		settings->SurfaceCommandsEnabled = FALSE;
 		settings->BitmapCacheV3Enabled = FALSE;
 
 		settings->BitmapCacheEnabled = TRUE;
@@ -668,6 +669,7 @@ rdpSettings* freerdp_settings_clone(rdpSettings* settings)
 		_settings->SoundBeepsEnabled = settings->SoundBeepsEnabled; /* 2944 */
 		_settings->SurfaceCommandsEnabled = settings->SurfaceCommandsEnabled; /* 3520 */
 		_settings->FrameMarkerCommandEnabled = settings->FrameMarkerCommandEnabled; /* 3521 */
+		_settings->SurfaceFrameMarkerEnabled = settings->SurfaceFrameMarkerEnabled; /* 3522 */
 		_settings->RemoteFxOnly = settings->RemoteFxOnly; /* 3648 */
 		_settings->RemoteFxCodec = settings->RemoteFxCodec; /* 3649 */
 		_settings->RemoteFxImageCodec = settings->RemoteFxImageCodec; /* 3652 */


### PR DESCRIPTION
This patch adds the parsing for the surface framemarker flag, so that we can test it later.
